### PR TITLE
Changed KnowAnyAddons.md

### DIFF
--- a/Writerside/topics/compatibility/KnowAnyAddons.md
+++ b/Writerside/topics/compatibility/KnowAnyAddons.md
@@ -14,6 +14,6 @@
 - [Weeping Angels](https://modrinth.com/mod/weeping-angels)
 - [Regeneration](https://modrinth.com/mod/regeneration)
 - [Tardis Refined: ExtraShells](https://modrinth.com/mod/extrashells)
-- [WhoCosmetics](https://modrinth.com/mod/whocosmetics)
+- [Doctor Who: Deco (formerly WhoCosmetics)]([https://modrinth.com/mod/whocosmetics](https://modrinth.com/mod/doctor-who-deco))
 - [TriadTech](https://modrinth.com/mod/triadtech)
 - [Black Archive](https://modrinth.com/mod/black-archive)


### PR DESCRIPTION
I changed the WhoCosmetics in KnowAnyAddons.md to its new location of https://modrinth.com/mod/doctor-who-deco and renamed it to "Doctor Who: Deco (formerly WhoCosmetics)"